### PR TITLE
Changes config to use babel 6 presets/plugins, removed legacy decorator

### DIFF
--- a/packages/babel-config-node/index.js
+++ b/packages/babel-config-node/index.js
@@ -1,18 +1,14 @@
 module.exports = {
-  presets: [
-    [
-      '@babel/preset-stage-1',
-      {
-        decoratorsLegacy: true
-      }
-    ],
-    [
-      '@babel/preset-env',
-      {
+    presets: [
+      ['env', {
         targets: {
           node: 'current'
         }
-      }
+      }],
+      'stage-2'
+    ],
+    plugins: [
+      'transform-class-properties',
+      'transform-object-rest-spread'
     ]
-  ]
 };

--- a/packages/babel-config-node/package.json
+++ b/packages/babel-config-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsandf/babel-config-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.js",
   "author": "GS&F Devs <mindreactor@gsandf.com> (https://gsandf.com/)",
   "license": "MIT"


### PR DESCRIPTION
The `@babel` packages are for babel 7, which is still in beta. This PR also changes the preset from stage-1 to stage-2 and adds a couple plugins that we frequently use.